### PR TITLE
Feat: 회원가입 시 이메일 인증 구현

### DIFF
--- a/ossKobot/settings.py
+++ b/ossKobot/settings.py
@@ -104,6 +104,7 @@ ACCOUNT_EMAIL_VERIFICATION = 'mandatory' # 필요하게 설정할꺼면 나중�
 ACCOUNT_UNIQUE_EMAIL = True
 ACCOUNT_USERNAME_REQUIRED = True
 ACCOUNT_AUTHENTICATED_LOGIN_REDIRECTS = True
+ACCOUNT_ADAPTER = 'users.adapter.CustomAccountAdapter'
 
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = 'smtp.gmail.com'
@@ -114,6 +115,10 @@ EMAIL_HOST_PASSWORD = get_secret("EMAIL_HOST_PASSWORD")
 DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
 ACCOUNT_EMAIL_CONFIRMATION_TEMPLATE = 'templates/account/email/email_confirmation_signup_message.html'  # 사용자 정의 템플릿 경로
 ACCOUNT_EMAIL_CONFIRMATION_HTML_TEMPLATE = 'account/email/email_confirmation_signup_message.html'  # 사용자 정의 템플릿 경로
+ACCOUNT_RATE_LIMITS = { # 이메일 인증 재전송에 대한 속도 제한 설정
+    'confirm_email': '5/m'
+}
+
 
 SOCIALACCOUNT_PROVIDERS = {
     'kakao': {

--- a/ossKobot/settings.py
+++ b/ossKobot/settings.py
@@ -100,9 +100,20 @@ REST_AUTH = {
 
 ACCOUNT_AUTHENTICATION_METHOD = 'email'
 ACCOUNT_EMAIL_REQUIRED = True
-ACCOUNT_EMAIL_VERIFICATION = 'none' # 필요하게 설정할꺼면 나중에 mandatory 로 바꾸면 됨.
+ACCOUNT_EMAIL_VERIFICATION = 'mandatory' # 필요하게 설정할꺼면 나중에 mandatory 로 바꾸면 됨.
 ACCOUNT_UNIQUE_EMAIL = True
 ACCOUNT_USERNAME_REQUIRED = True
+ACCOUNT_AUTHENTICATED_LOGIN_REDIRECTS = True
+
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST = 'smtp.gmail.com'
+EMAIL_PORT = 587
+EMAIL_USE_TLS = True
+EMAIL_HOST_USER = get_secret("EMAIL_HOST_USER")
+EMAIL_HOST_PASSWORD = get_secret("EMAIL_HOST_PASSWORD")
+DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
+ACCOUNT_EMAIL_CONFIRMATION_TEMPLATE = 'templates/account/email/email_confirmation_signup_message.html'  # 사용자 정의 템플릿 경로
+ACCOUNT_EMAIL_CONFIRMATION_HTML_TEMPLATE = 'account/email/email_confirmation_signup_message.html'  # 사용자 정의 템플릿 경로
 
 SOCIALACCOUNT_PROVIDERS = {
     'kakao': {

--- a/users/adapter.py
+++ b/users/adapter.py
@@ -1,0 +1,83 @@
+from allauth.account.adapter import DefaultAccountAdapter
+from allauth.account.utils import user_email
+from allauth.account.models import EmailAddress
+from django.template.loader import render_to_string
+from django.utils.http import urlsafe_base64_encode
+from django.utils.encoding import force_bytes
+from django.core.mail import EmailMultiAlternatives
+from django.contrib import messages
+
+def user_pk_to_url_str(user):
+    return urlsafe_base64_encode(force_bytes(user.pk))
+
+class CustomAccountAdapter(DefaultAccountAdapter):
+    def send_confirmation_mail(self, request, emailconfirmation, signup):
+        # 커스텀 템플릿 경로 설정
+        current_site = request.get_host()
+        activate_url = self.get_email_confirmation_url(request, emailconfirmation)
+        context = {
+            "user": emailconfirmation.email_address.user,
+            "activate_url": activate_url,
+            "current_site": current_site,
+            "key": emailconfirmation.key,
+        }
+        # 커스텀 템플릿 사용
+        subject = render_to_string("account/email/email_confirmation_signup_subject.txt", context)
+        subject = ''.join(subject.splitlines())  # remove superfluous line breaks
+        message = render_to_string("account/email/email_confirmation_signup_message.txt", context)
+        html_message = render_to_string("account/email/email_confirmation_signup_message.html", context)
+
+
+         # Django의 EmailMultiAlternatives 사용
+        email = EmailMultiAlternatives(
+            subject,
+            message,
+            to=[emailconfirmation.email_address.email]
+        )
+        email.attach_alternative(html_message, "text/html")
+        email.send()
+    
+        # self.send_mail("account/email/email_confirmation_signup_message.html", emailconfirmation.email_address.email, context)
+    
+    def send_email_confirmation(self, request, user, signup=False, email=None):
+        email_address = None
+        if not email:
+            email = user_email(user)
+        if not email:
+            email_address = (
+                EmailAddress.objects.filter(user=user).order_by("verified", "pk").first()
+            )
+            if email_address:
+                email = email_address.email
+
+        if email:
+            if email_address is None:
+                try:
+                    email_address = EmailAddress.objects.get_for_user(user, email)
+                except EmailAddress.DoesNotExist:
+                    pass
+            if email_address is not None:
+                if not email_address.verified:
+                    send_email = self.should_send_confirmation_mail(
+                        request, email_address, signup
+                    )
+                    if send_email:
+                        email_address.send_confirmation(request, signup=signup)
+                else:
+                    send_email = False
+            else:
+                send_email = True
+                email_address = EmailAddress.objects.add_email(
+                    request, user, email, signup=signup, confirm=True
+                )
+                assert email_address
+            # At this point, if we were supposed to send an email we have sent it.
+            if send_email:
+                self.add_message(
+                    request,
+                    messages.INFO,
+                    "templates/account/email/email_confirmation_signup_message.html",
+                    {"email": email, "login": not signup, "signup": signup},
+                )
+        if signup:
+            self.stash_user(request, user_pk_to_url_str(user))

--- a/users/admin.py
+++ b/users/admin.py
@@ -8,7 +8,7 @@ class BookInline(admin.TabularInline):
     extra = 1
 class CustomUserAdmin(UserAdmin):
     model = CustomUser
-    list_display = ('email', 'username', 'is_staff', 'is_active')
+    list_display = ('email', 'username', 'is_staff', 'is_active', 'is_verified')
     list_filter = ('is_staff', 'is_active')
     fieldsets = (
         (None, {'fields': ('email', 'username', 'password')}),

--- a/users/admin.py
+++ b/users/admin.py
@@ -1,7 +1,6 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from .models import CustomUser
-from books.models import Book
 
 class BookInline(admin.TabularInline):
     model = CustomUser.mybook_list.through

--- a/users/models.py
+++ b/users/models.py
@@ -37,6 +37,7 @@ class CustomUser(AbstractBaseUser, PermissionsMixin):
     profile_image = models.ImageField(upload_to='profile_images/', blank=True, null=True)
     is_active = models.BooleanField(default=True)
     is_staff = models.BooleanField(default=False)
+    is_verified = models.BooleanField(default=False)
     is_superuser = models.BooleanField(default=False)
     date_joined = models.DateTimeField(auto_now_add=True)
     date_updated = models.DateTimeField(auto_now=True)

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 from .views import *
+from allauth.account.views import confirm_email
 
 router = DefaultRouter()
 
@@ -13,6 +14,8 @@ urlpatterns = [
     # dj-rest-auth
     path('auth/', include('dj_rest_auth.urls')),
     path('auth/registration/', include('dj_rest_auth.registration.urls')),
+    path("auth/registration/account-confirm-email/<str:key>", CustomConfirmEmailView.as_view(),
+        name="account_confirm_email"),
     # path('kakao-login/', kakao_login_view, name='kakao-login'),
     # path('kakao-user-info/', kakao_user_info, name='kakao-user-info'),
 

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,7 +1,6 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 from .views import *
-from allauth.account.views import confirm_email
 
 router = DefaultRouter()
 
@@ -16,6 +15,7 @@ urlpatterns = [
     path('auth/registration/', include('dj_rest_auth.registration.urls')),
     path("auth/registration/account-confirm-email/<str:key>", CustomConfirmEmailView.as_view(),
         name="account_confirm_email"),
+    path('auth/custom_login/', CustomLoginView.as_view(), name='rest_login'),
     # path('kakao-login/', kakao_login_view, name='kakao-login'),
     # path('kakao-user-info/', kakao_user_info, name='kakao-user-info'),
 

--- a/users/views.py
+++ b/users/views.py
@@ -4,6 +4,9 @@ from django.shortcuts import render
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
+from allauth.account.views import ConfirmEmailView
+from allauth.account.models import EmailConfirmationHMAC
+
 
 class ProfileView(APIView):
     permission_classes = [IsAuthenticated]
@@ -17,6 +20,38 @@ class ProfileView(APIView):
         })
 
 
+class CustomConfirmEmailView(ConfirmEmailView):
+    template_name = 'account/email/success_verify_email.html'
+    
+    def get_template_names(self) -> list[str]:
+        return super().get_template_names()
+    
+    def dispatch(self, request, *args, **kwargs):
+        key = kwargs.get('key', None)
+        print(f'dispatch called with key: {key}')
+        if key:
+            email_confirmation = EmailConfirmationHMAC.from_key(key)
+            if email_confirmation:
+                email_address = email_confirmation.email_address
+                print(f'EmailConfirmation found: {email_confirmation}') 
+                
+                # 여기서 이메일 인증을 완료
+                email_confirmation.confirm(request)
+                
+                # 다시 한 번 확인
+                email_address.refresh_from_db()
+                
+                if email_address and email_address.verified:
+                    user = email_address.user
+                    user.is_verified = True
+                    user.save()
+                    print(f'User {user.email} verified and saved')
+                else:
+                    print(f'EmailAddress not verified or not found: {email_address.email if email_address else "None"}')
+            else:
+                print(f'EmailConfirmation not found for key: {key}')
+        
+        return super().dispatch(request, *args, **kwargs)
 
 #카카오톡 로그인 뷰
 """from django.shortcuts import render

--- a/users/views.py
+++ b/users/views.py
@@ -1,11 +1,17 @@
 from django.contrib.sites import requests
 from django.http import JsonResponse
-from django.shortcuts import render
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from allauth.account.views import ConfirmEmailView
 from allauth.account.models import EmailConfirmationHMAC
+from allauth.account.models import EmailAddress
+from rest_framework import status
+from dj_rest_auth.views import LoginView
+from django.contrib.auth import authenticate, login
+
+from users.adapter import CustomAccountAdapter
+
 
 
 class ProfileView(APIView):
@@ -18,7 +24,6 @@ class ProfileView(APIView):
             'username': user.username,
             'is_staff': user.is_staff
         })
-
 
 class CustomConfirmEmailView(ConfirmEmailView):
     template_name = 'account/email/success_verify_email.html'
@@ -52,6 +57,84 @@ class CustomConfirmEmailView(ConfirmEmailView):
                 print(f'EmailConfirmation not found for key: {key}')
         
         return super().dispatch(request, *args, **kwargs)
+
+
+
+class CustomLoginView(LoginView):
+    def post(self, request, *args, **kwargs):
+        print('custom login view call')
+
+        # 요청에서 email과 password 가져오기
+        email = request.data.get('email')  # 이메일 필드
+        password = request.data.get('password')  # 비밀번호 필드
+        print(email)
+        print(password)
+
+        # 이메일로 사용자 인증
+        user = authenticate(request, username=email, password=password)
+
+        if user is not None:
+            # 이메일 주소로 사용자 가져오기
+            email_address = EmailAddress.objects.filter(email=email, primary=True).first()
+            if email_address and not email_address.verified:
+                
+                # 이메일 주소가 인증되지 않은 경우
+                adapter = CustomAccountAdapter()
+                adapter.send_email_confirmation(request, user)  # 인증 이메일 재전송
+                return Response(
+                    {"detail": "이메일 인증이 필요합니다. 인증 이메일이 재전송되었습니다."},
+                    status=status.HTTP_401_UNAUTHORIZED
+                )
+
+            # 이메일 인증이 완료된 경우 로그인
+            login(request, user)
+            return Response({"detail": "로그인 성공"}, status=status.HTTP_200_OK)
+        else:
+            # 로그인 실패 시 처리
+            return Response(
+                {"detail": "이메일 주소 또는 비밀번호가 잘못되었습니다."},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+    
+    
+# class CustomLoginView(LoginView):
+#     def post(self, request, *args, **kwargs):
+#         print('custom login view call')
+#         # 요청에서 email과 password 가져오기
+#         email = request.data.get('email')  # 이메일 필드
+#         password = request.data.get('password')  # 비밀번호 필드
+#         print(email)
+#         print(password)
+#         # 기본 로그인 기능 수행
+#         response = super().post(request, *args, **kwargs)
+#         print('debug1')
+#         # 로그인 실패 시 처리
+#         if response.status_code == status.HTTP_400_BAD_REQUEST:
+#             print('debug2')
+#             # 응답에서 non_field_errors를 확인
+#             if 'non_field_errors' in response.data:
+#                 for error in response.data['non_field_errors']:
+#                     if "이메일 주소가 확인되지 않았습니다." in error:
+#                         try:
+#                             # 이메일 주소로 사용자 가져오기
+#                             email_address = EmailAddress.objects.get(email=email, primary=True)
+                            
+#                             # 이메일 주소가 인증되지 않은 경우
+#                             if email_address and not email_address.verified:
+#                                 user = email_address.user
+#                                 send_email_confirmation(request, user)  # 인증 이메일 재전송
+#                                 return Response(
+#                                     {"detail": "이메일 인증이 필요합니다. 인증 이메일이 재전송되었습니다."},
+#                                     status=status.HTTP_401_UNAUTHORIZED
+#                                 )
+#                         except EmailAddress.DoesNotExist:
+#                             return Response(
+#                                 {"detail": "이메일 주소가 존재하지 않습니다."},
+#                                 status=status.HTTP_400_BAD_REQUEST
+#                             )
+
+#         return response  # 로그인 성공 또는 다른 에러에 대한 응답 반환
+    
 
 #카카오톡 로그인 뷰
 """from django.shortcuts import render


### PR DESCRIPTION
회원가입에 이메일 인증 기능을 추가했습니다. 이메일 인증을 하지 않으면 로그인이 불가하고, 인증 링크가 재전송됩니다.
host 메일 주소와 비밀번호는 secret.json으로 관리되며 slack에 전송해두었습니다.

1. 회원가입 post 시 '확인 이메일을 발송했습니다' 반환
<img width="992" alt="image" src="https://github.com/user-attachments/assets/de13783c-047a-4b24-b5f4-9d7690216483">


2. 발송된 이메일 확인 후 인증하기 버튼 클릭
<img width="933" alt="image" src="https://github.com/user-attachments/assets/709b97c4-cb66-42a8-a856-7d830c3f266a">


3. 이메일 인증 완료
<img width="890" alt="image" src="https://github.com/user-attachments/assets/6d754c7a-9035-468a-a771-f54059347693">

4. 로그인


*이메일 인증이 되지 않은 상태로 로그인 시도 시 인증 메일이 재전송됩니다.
