### PR TITLE
Feat: 로그인, 회원가입 에러처리

### DIFF
--- a/users/models.py
+++ b/users/models.py
@@ -32,7 +32,7 @@ class CustomUserManager(BaseUserManager):
 
 
 class CustomUser(AbstractBaseUser, PermissionsMixin):
-    email = models.EmailField(unique=True)
+    email = models.EmailField()
     username = models.CharField(max_length=255)
     birth_date = models.DateField(null=True)
     profile_image = models.ImageField(upload_to='profile_images/', blank=True, null=True)

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -10,19 +10,7 @@ class CustomUserSerializer(serializers.ModelSerializer):
         model = CustomUser
         fields = ['username', 'email', 'password1', 'password2', 'birth_date']
 
-
-    def validate(self, data):
-        if data['password1'] != data['password2']:
-            raise serializers.ValidationError("Passwords do not match.")
-        
-        validate_password(data['password1'])
-        
-        return data
-
     def create(self, validated_data):
-        if validated_data['password1'] != validated_data['password2']:
-            raise serializers.ValidationError({"password": "Passwords do not match."})
-
         user = CustomUser(
             username=validated_data['username'],
             email=validated_data['email'],

--- a/users/urls.py
+++ b/users/urls.py
@@ -6,6 +6,9 @@ router = DefaultRouter()
 
 urlpatterns = [
     path('', include(router.urls)),
+    path('check-username/', CheckUsernameView.as_view(), name='check-username'),
+    path('check-email/', CheckEmailView.as_view(), name='check-email'),
+    
 
     # allauth
     path('accounts/', include('allauth.urls')),

--- a/users/views.py
+++ b/users/views.py
@@ -35,6 +35,19 @@ class RegisterView(generics.CreateAPIView):
         # 이메일 인증 메일 전송
         send_email_confirmation(request, user)
 
+class CheckUsernameView(APIView):
+    def post(self, request, *args, **kwargs):
+        username = request.data.get('username')
+        if User.objects.filter(username=username).exists():
+            return Response({"detail": "이미 존재하는 닉네임입니다."}, status=status.HTTP_400_BAD_REQUEST)
+        return Response({"detail": "사용 가능한 닉네임입니다."}, status=status.HTTP_200_OK)
+
+class CheckEmailView(APIView):
+    def post(self, request, *args, **kwargs):
+        email = request.data.get('email')
+        if User.objects.filter(email=email).exists():
+            return Response({"detail": "이미 존재하는 이메일 주소입니다."}, status=status.HTTP_400_BAD_REQUEST)
+        return Response({"detail": "사용 가능한 이메일 주소입니다."}, status=status.HTTP_200_OK)
 
 class CustomConfirmEmailView(ConfirmEmailView):
     template_name = 'account/email/success_verify_email.html'

--- a/users/views.py
+++ b/users/views.py
@@ -143,45 +143,6 @@ class ProfileView(APIView):
             'is_staff': user.is_staff
         })
 
-# class CustomLoginView(LoginView):
-#     def post(self, request, *args, **kwargs):
-#         print('custom login view call')
-#         # 요청에서 email과 password 가져오기
-#         email = request.data.get('email')  # 이메일 필드
-#         password = request.data.get('password')  # 비밀번호 필드
-#         print(email)
-#         print(password)
-#         # 기본 로그인 기능 수행
-#         response = super().post(request, *args, **kwargs)
-#         print('debug1')
-#         # 로그인 실패 시 처리
-#         if response.status_code == status.HTTP_400_BAD_REQUEST:
-#             print('debug2')
-#             # 응답에서 non_field_errors를 확인
-#             if 'non_field_errors' in response.data:
-#                 for error in response.data['non_field_errors']:
-#                     if "이메일 주소가 확인되지 않았습니다." in error:
-#                         try:
-#                             # 이메일 주소로 사용자 가져오기
-#                             email_address = EmailAddress.objects.get(email=email, primary=True)
-                            
-#                             # 이메일 주소가 인증되지 않은 경우
-#                             if email_address and not email_address.verified:
-#                                 user = email_address.user
-#                                 send_email_confirmation(request, user)  # 인증 이메일 재전송
-#                                 return Response(
-#                                     {"detail": "이메일 인증이 필요합니다. 인증 이메일이 재전송되었습니다."},
-#                                     status=status.HTTP_401_UNAUTHORIZED
-#                                 )
-#                         except EmailAddress.DoesNotExist:
-#                             return Response(
-#                                 {"detail": "이메일 주소가 존재하지 않습니다."},
-#                                 status=status.HTTP_400_BAD_REQUEST
-#                             )
-
-#         return response  # 로그인 성공 또는 다른 에러에 대한 응답 반환
-    
-
 #카카오톡 로그인 뷰
 """from django.shortcuts import render
 


### PR DESCRIPTION
- 로그인 시 에러메세지
    1. 등록된 이메일 주소가 아닙니다.
      : 사용자가 입력한 이메일 주소가 데이터베이스에 존재하지 않는 경우
    2. 비밀번호가 잘못되었습니다.
      : 사용자가 입력한 이메일 주소는 존재하지만 비밀번호가 일치하지 않는 경우.
    3. 이메일 주소 또는 비밀번호가 잘못되었습니다.
      : 위에서 에러처리가 되지 않을 경우. 사용자에게 구체적인 정보를 제공하지 않기 위해 사용

- 회원가입 시
    - 닉네임 중복 확인 API로 체크
    - 이메일 중복 확인 API로 체크

<img width="1362" alt="image" src="https://github.com/user-attachments/assets/b44ee42e-dd2d-4a31-ac6b-2e55ad14a10d">

Front-End에서 처리해주는 부분들은 모두 제거하였습니다.(비밀번호 일치 여부 확인, 비밀번호 8자리이상 특수문자 등등)
