### PR TITLE
Fix: 책표지 url 수정

### DIFF
--- a/books/serializers.py
+++ b/books/serializers.py
@@ -163,3 +163,11 @@ class WrittenBookSerializer(serializers.ModelSerializer):
         # character와 speaker를 활용한 추가 로직 (저장, 로그, 알림 등)을 여기에 추가 가능
 
         return written_book
+    
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+        
+        if instance.cover_image:
+            representation['cover_image'] = f"/media/{instance.cover_image}"
+
+        return representation


### PR DESCRIPTION
to_representation 메서드를 추가하여 도메인 부분을 제거하고 media 경로만 반환하도록 수정하였습니다.

![image](https://github.com/user-attachments/assets/843da7a4-6621-48f0-952e-d53a12c577bc)
